### PR TITLE
Adds ability to specify PASSWORD, SALT, and FETCH_URL_NAME in django settings

### DIFF
--- a/django_encrypted_filefield/constants.py
+++ b/django_encrypted_filefield/constants.py
@@ -1,12 +1,18 @@
 import os
+from django.conf import settings
 
 
-def get_bytes(name):
-    r = os.getenv("DEFF_{}".format(name))
-    if r:
-        return bytes(r.encode("utf-8"))
+def _get_setting(name):
+    setting_name = "DEFF_{}".format(name)
+    return os.getenv(setting_name, getattr(settings, setting_name, None))
+
+
+def get_bytes(v):
+    if v:
+        return bytes(v.encode("utf-8"))
     return None
 
-SALT = get_bytes("SALT")
-PASSWORD = get_bytes("PASSWORD")
-FETCH_URL_NAME = os.getenv("DEFF_FETCH_URL_NAME")
+
+SALT = get_bytes(_get_setting("SALT"))
+PASSWORD = get_bytes(_get_setting("PASSWORD"))
+FETCH_URL_NAME = _get_setting("FETCH_URL_NAME")

--- a/django_encrypted_filefield/constants.py
+++ b/django_encrypted_filefield/constants.py
@@ -1,5 +1,6 @@
 import os
 from django.conf import settings
+from django.utils import six
 
 
 def _get_setting(name):
@@ -8,9 +9,11 @@ def _get_setting(name):
 
 
 def get_bytes(v):
-    if v:
+    if isinstance(v, six.string_types):
         return bytes(v.encode("utf-8"))
-    return None
+    if not v:
+        return None
+    return v
 
 
 SALT = get_bytes(_get_setting("SALT"))


### PR DESCRIPTION
This PR does 2 things:

1. Adds ability to specify PASSWORD, SALT, and FETCH_URL_NAME in django settings. Also maintains backwards compatibility by delegating to env vars if the settings do not exist.
2. Allows `PASSWORD` and `SALT` to be specified as bytes (instead of giving them as strings, then converting to bytes). This change should also be completely backwards compatible, as specifying them as strings will maintain the same behavior.