### PR TITLE
Error using django.core.urlresolvers

### DIFF
--- a/demo/views.py
+++ b/demo/views.py
@@ -1,7 +1,6 @@
 try:
     from django.urls import reverse
-except ImportError:
-    # Django < v2.0
+except ImportError:  # Django < 2.0 # pragma: no cover
     from django.core.urlresolvers import reverse
 
 from django.views.generic import CreateView, DetailView

--- a/demo/views.py
+++ b/demo/views.py
@@ -1,4 +1,5 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
+
 from django.views.generic import CreateView, DetailView
 
 from django_encrypted_filefield.views import FetchView

--- a/demo/views.py
+++ b/demo/views.py
@@ -1,4 +1,8 @@
-from django.urls import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    # Django < v2.0
+    from django.core.urlresolvers import reverse
 
 from django.views.generic import CreateView, DetailView
 

--- a/django_encrypted_filefield/checks.py
+++ b/django_encrypted_filefield/checks.py
@@ -1,8 +1,7 @@
 from django.core.checks import Error, register
 try:
     from django.urls import reverse, NoReverseMatch
-except ImportError:
-    # Django < v2.0
+except ImportError:  # Django < 2.0 # pragma: no cover
     from django.core.urlresolvers import reverse, NoReverseMatch
 
 from .constants import FETCH_URL_NAME, PASSWORD, SALT

--- a/django_encrypted_filefield/checks.py
+++ b/django_encrypted_filefield/checks.py
@@ -1,7 +1,5 @@
-import os
-
 from django.core.checks import Error, register
-from django.core.urlresolvers import reverse, NoReverseMatch
+from django.urls import reverse, NoReverseMatch
 
 from .constants import FETCH_URL_NAME, PASSWORD, SALT
 

--- a/django_encrypted_filefield/checks.py
+++ b/django_encrypted_filefield/checks.py
@@ -1,5 +1,9 @@
 from django.core.checks import Error, register
-from django.urls import reverse, NoReverseMatch
+try:
+    from django.urls import reverse, NoReverseMatch
+except ImportError:
+    # Django < v2.0
+    from django.core.urlresolvers import reverse, NoReverseMatch
 
 from .constants import FETCH_URL_NAME, PASSWORD, SALT
 

--- a/django_encrypted_filefield/fields.py
+++ b/django_encrypted_filefield/fields.py
@@ -1,5 +1,10 @@
 from io import BytesIO
-from django.urls import reverse
+
+try:
+    from django.urls import reverse
+except ImportError:
+    # Django < v2.0
+    from django.core.urlresolvers import reverse
 
 from django.db.models.fields.files import (
     FieldFile,

--- a/django_encrypted_filefield/fields.py
+++ b/django_encrypted_filefield/fields.py
@@ -1,7 +1,6 @@
 from io import BytesIO
+from django.urls import reverse
 
-from django.conf import settings
-from django.core.urlresolvers import reverse
 from django.db.models.fields.files import (
     FieldFile,
     FileField,

--- a/django_encrypted_filefield/fields.py
+++ b/django_encrypted_filefield/fields.py
@@ -2,8 +2,7 @@ from io import BytesIO
 
 try:
     from django.urls import reverse
-except ImportError:
-    # Django < v2.0
+except ImportError:  # Django < 2.0 # pragma: no cover
     from django.core.urlresolvers import reverse
 
 from django.db.models.fields.files import (


### PR DESCRIPTION
On Django 2.0, the `django.core.urlresolvers` module is removed in favor of its new location, `django.urls`.

https://docs.djangoproject.com/en/2.0/releases/2.0/

It appears `django-encrypted-filefield` is using `django.core.urlresolvers` in three places:

demo/views.py
django_encrypted_filefiled/checks.py and fields.py

Wrapped both versions in a try statement, so if django.urls fails because django < 2.0 is installed, then it falls back on `django.core.urlresolvers`.

Test seems to work fine on django 2.0, however I haven't tested in an actual app.