### PR TITLE
Django 3 compatibility

### DIFF
--- a/django_encrypted_filefield/constants.py
+++ b/django_encrypted_filefield/constants.py
@@ -1,6 +1,6 @@
 import os
+import six
 from django.conf import settings
-from django.utils import six
 
 
 def _get_setting(name):

--- a/django_encrypted_filefield/tests/test_constants.py
+++ b/django_encrypted_filefield/tests/test_constants.py
@@ -1,5 +1,5 @@
+import six
 from django.test import TestCase, override_settings
-from django.utils import six
 from django_encrypted_filefield.constants import _get_setting, get_bytes
 
 try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ Django>=1.11
 cryptography>=1.7.1
 requests>=2.12.4
 python-magic>=0.4.12,<0.5.0
+six>=1.0.0


### PR DESCRIPTION
The latest version of Django has removed the six library that is used by django-encrypted-filefield.

See:
https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis
_django.utils.six - Remove usage of this vendored library or switch to six._

The code in this pull request uses six libray instead of django.utils.six