### PR TITLE
Update for Django 3.2.2 settings.py using Path()

### DIFF
--- a/django_encrypted_filefield/views.py
+++ b/django_encrypted_filefield/views.py
@@ -44,18 +44,19 @@ class FetchView(View):
             raise Http404
 
         if self._is_url(path):
-
             content = requests.get(path, stream=True).raw.read()
 
         else:
+            MEDIA_ROOT = str(settings.MEDIA_ROOT)
 
             # Normalise the path to strip out naughty attempts
             path = os.path.normpath(path).replace(
-                settings.MEDIA_URL, settings.MEDIA_ROOT, 1
+                settings.MEDIA_URL.lstrip(
+                    "/"), MEDIA_ROOT.lstrip("/") + "/", 1
             )
 
             # Evil path request!
-            if not path.startswith(settings.MEDIA_ROOT):
+            if not path.startswith(MEDIA_ROOT):
                 raise Http404
 
             # The file requested doesn't exist locally.  A legit 404


### PR DESCRIPTION
I have taken no time past making work so I'm sure you can figure a far more precise and pythonic way to correct the error.
- Django 3.2.2 settings.py uses the pathlib.Path instead os.path.join()
- FetchView expected a string returned from MEDIA_ROOT but encountered a Path object instead.